### PR TITLE
fix: getCurrentJob when GitHub API job state is sluggish

### DIFF
--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -250,7 +250,7 @@ export async function getCurrentJob(octokit: InstanceType<typeof GitHub>): Promi
     core.debug(`runner_name: ${context.runnerName}\n` + 'workflow_run_jobs:' +
         JSON.stringify(currentWorkflowRunJobs, null, 2));
     const currentJobs = currentWorkflowRunJobs
-        .filter((job) => job.status.includes(["in_progress", "queued"]))
+        .filter((job) => job.status === "in_progress" || job.status === "queued")
         .filter((job) => {
           // job.runner_group_id 0 represents the GitHub Actions hosted runners
           if (job.runner_group_id === 0 && job.runner_name === "GitHub Actions") {

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -250,7 +250,7 @@ export async function getCurrentJob(octokit: InstanceType<typeof GitHub>): Promi
     core.debug(`runner_name: ${context.runnerName}\n` + 'workflow_run_jobs:' +
         JSON.stringify(currentWorkflowRunJobs, null, 2));
     const currentJobs = currentWorkflowRunJobs
-        .filter((job) => job.status === "in_progress")
+        .filter((job) => job.status.includes(["in_progress", "queued"]))
         .filter((job) => {
           // job.runner_group_id 0 represents the GitHub Actions hosted runners
           if (job.runner_group_id === 0 && job.runner_name === "GitHub Actions") {


### PR DESCRIPTION
Hi everyone! First, I want to thank all the developers for this action. Fetching the GitHub Job ID is helpful.

I've been using this action for approximately two to three weeks, but yesterday, I started encountering failures when attempting to run it, receiving the following error. `Current job could not be determined.`

While reviewing the GitHub API response, I found that the job status was "queued" instead of "in_progress." This discrepancy contributed to the issue of not being able to locate the job ID. If I'm correct, each running/queued job has a unique runner, so we can include the "queued" state in the filter when fetching the jobs to address the case where the GitHub API may be sluggish.

If you have a better approach, please share it. I would be glad to help, and I look forward to your feedback.