### PR TITLE
fix: derive job context from run context when the jobs API fails

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -52,6 +52,23 @@ export const action = run(async () => {
     const jobHtmlUrl = process.env.GITHUB_JOB_HTML_URL ?? job.html_url ?? ''
     core.setOutput('job_html_url', jobHtmlUrl)
     core.exportVariable('GITHUB_JOB_HTML_URL', jobHtmlUrl)
+  }).catch((error: unknown) => {
+    // On a jobs-API failure, derive what we can from the run context (notably
+    // job_html_url) instead of failing the action; job_name/runner_id need the API.
+    core.warning('Could not fetch the current job from the GitHub API; deriving job' +
+        ' context from the run context (job_name and runner_id will be missing). ' +
+        (error instanceof Error ? error.message : String(error)))
+
+    core.setOutput('runner_name', context.runnerName)
+
+    const jobCheckRunId = context.jobCheckRunId
+    core.setOutput('job_check_run_id', jobCheckRunId)
+    core.exportVariable('GITHUB_JOB_CHECK_RUN_ID', jobCheckRunId)
+
+    const jobHtmlUrl = process.env.GITHUB_JOB_HTML_URL ??
+        `${context.serverUrl}/${context.repository}/actions/runs/${context.runId}/job/${jobCheckRunId}`
+    core.setOutput('job_html_url', jobHtmlUrl)
+    core.exportVariable('GITHUB_JOB_HTML_URL', jobHtmlUrl)
   });
 
   await getCurrentDeployment(octokit).catch((error) => {


### PR DESCRIPTION
## Problem

In `index.ts`, `getCurrentJob()` has no `.catch()` — unlike `getCurrentDeployment()` right below it:

```ts
await getCurrentJob(octokit).then((job) => {
  // sets runner_*, job_name, job_check_run_id, job_html_url + GITHUB_JOB_HTML_URL
});
```

So when `getJobForWorkflowRun` returns a sporadic **`5xx`**, the rejection propagates, the whole action fails, and every `job_*` output — including the exported `GITHUB_JOB_HTML_URL` env var — is left **unset**, even though the run-level outputs were already emitted.

```
##[error]Server Error
HttpError: Server Error
    at getCurrentJob (.../lib/actions.ts)
    at .../index.ts
```

It's intermittent (only when that one call happens to 5xx) — the same jobs-API flakiness the existing `sleep(2000)` already works around.

## Fix

Add a `.catch()` that, rather than giving up, emits the job context that is **derivable from the run context without the API**:

- **`job_html_url`** is exactly `${serverUrl}/${repository}/actions/runs/${runId}/job/${jobCheckRunId}` — and `getJobForWorkflowRun` is itself called with `job_id = context.jobCheckRunId`, so the constructed URL equals the one the API would have returned. The most-used output stays correct even during a complete jobs-API outage.
- **`job_check_run_id`** and **`runner_name`** likewise come from the run context.

Only `job_name` and `runner_id` genuinely require the API; those are skipped with a `core.warning`. The happy path is untouched.

```ts
}).catch((error: unknown) => {
  core.warning('Could not fetch the current job from the GitHub API; deriving job' +
      ' context from the run context (job_name and runner_id will be missing). ' +
      (error instanceof Error ? error.message : String(error)))

  core.setOutput('runner_name', context.runnerName)

  const jobCheckRunId = context.jobCheckRunId
  core.setOutput('job_check_run_id', jobCheckRunId)
  core.exportVariable('GITHUB_JOB_CHECK_RUN_ID', jobCheckRunId)

  const jobHtmlUrl = process.env.GITHUB_JOB_HTML_URL ??
      `${context.serverUrl}/${context.repository}/actions/runs/${context.runId}/job/${jobCheckRunId}`
  core.setOutput('job_html_url', jobHtmlUrl)
  core.exportVariable('GITHUB_JOB_HTML_URL', jobHtmlUrl)
});
```

`npm run lint` passes. I left `dist/` out — `main` currently has unrelated `dist/` drift from the #410 undici bump, so rebuilding here would bury this change under that churn; happy to push the rebuilt `dist/` if you'd prefer the PR self-contained.